### PR TITLE
Make hiredis an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
 		"test": "mocha ./test/test.js"
 	},
 	"dependencies": {
-		"hiredis": "*",
 		"redis": "*",
 		"underscore": "*"
+	},
+	"optionalDependencies": {
+		"hiredis": "*"
 	},
 	"devDependencies": {
 		"mocha": "*",


### PR DESCRIPTION
Hiredis is not a required dependency for redis. in the cases where npm install will not build hiredis successfully then it is nice to still be able to use this library. 
