### PR TITLE
[Redis-Session] - Add the expire command on create & set methods to allo...

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,7 +372,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
         /* You can pass the new optionnal parameter to precise if you want increase the expire time */
         if(options.increaseExpire)
-          mc.push(["expire",  "" + this.redisns + options.app + ":" + token ,  parseInt(options.ttl)]);
+          mc.push(["expire",  "" + thekey ,  parseInt(options.ttl)]);
 
         if (resp.idle > 1) {
           mc.push(["hset", thekey, "la", _this._now()]);

--- a/index.js
+++ b/index.js
@@ -119,6 +119,13 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
         }
       }
       mc.push(thesession);
+
+			/*
+      * Only an 'expire command' can allow to redis to send an event when the object is removed from redis
+      * With Redis -v >= 2.8
+      * */
+      mc.push(["expire",  "" + this.redisns + options.app + ":" + token ,  parseInt(options.ttl)]);
+
       this.redis.multi(mc).exec(function(err, resp) {
         if (err) {
           cb(err);
@@ -362,6 +369,11 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
         thekey = "" + _this.redisns + options.app + ":" + options.token;
         mc = _this._createMultiStatement(options.app, options.token, resp.id, resp.ttl);
         mc.push(["hincrby", thekey, "w", 1]);
+
+        /* You can pass the new optionnal parameter to precise if you want increase the expire time */
+        if(options.increaseExpire)
+          mc.push(["expire",  "" + this.redisns + options.app + ":" + token ,  parseInt(options.ttl)]);
+
         if (resp.idle > 1) {
           mc.push(["hset", thekey, "la", _this._now()]);
         }


### PR DESCRIPTION
Add the expire command on create & set methods to allow the the use of events, like expire emit providing by redis. If you just precise a ttl, the resource is well deleted but no event is triggered

In this exemple , I use the RedisNotifier module (redis-notifier : https://www.npmjs.org/package/redis-notifier) , but it was to allow the event emission
Tell me if you do not think it's appropriate or I'll continue is that way ;)

With RedisNotifier & Redis Session, I can 

``` javascript 

// Create the session
session.create({
    app : rsapp,
    id  : idUser,
    ip  : ipUser,
    ttl : 10,
    d   : {
        cartToken: cartAdded.cartToken,
        cartUid: cartAdded.uid
    }}, function (err, sessionGen) {
            cartAdded
                ._set('sessionToken', sessionGen.token).update();
});

rsKeyBeg = 'rs:'+yournamespace+':';

// Session is removed, an event is emitted from the redis server, and I can remove My cart
var eventNotifier = new RedisNotifier(redis, {
    redis : { host : 1234, port : locahost},
    expired : true,
    del : true,
    logLevel : 'INFO' //Defaults To INFO
});

eventNotifier.on('message', function(pattern, channelPattern, emittedKey) {
    var channel = this.parseMessageChannel(channelPattern);
    switch(channel.key) {
     case 'expired':
         cart.removeBySessionToken(emittedKey.replace(rsKeyBeg,''));
         break;
     default:
        logger.debug("Unrecognized Channel Type:" + channel.type);
     }
});

// My cart is removed
```