### PR TITLE
Shut up redis-sessions' WIPING: NN Sessions

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,16 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
   EventEmitter = require("events").EventEmitter;
 
+  var debug;
+  if (process.env.REDIS_SESSIONS_DEBUG && /true/.test(process.env.REDIS_SESSIONS_DEBUG)) {
+    debug = function (x) {
+      console.log(x);
+    };
+  } else {
+    debug = function () {
+    };
+  }
+
   RedisSessions = (function(_super) {
     __extends(RedisSessions, _super);
 
@@ -615,7 +625,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
           return;
         }
         if (resp.length) {
-          console.log("WIPING:", resp.length, " sessions");
+          debug("WIPING:", resp.length, " sessions");
           _.each(resp, function(e) {
             var options;
             e = e.split(':');


### PR DESCRIPTION
I have an app log with thousands of WIPING: NN Sessions messages.
They don't add anything to the log in production, and they force me to grep for actual messages.
This debug function will make them configurable.

`export REDIS_SESSIONS_DEBUG=true`

before running server on dev env and you're getting all messages back.
