### PR TITLE
Fixed mistyping in create example at readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ rs.create({
   app: rsapp,
   id: "user1001",
   ip: "192.168.22.58",
-  ttl: 3600},
+  ttl: 3600,
   d: { 
     foo: "bar",
     unread_msgs: 34
+  }
   },
   function(err, resp) {
     // resp should be something like 


### PR DESCRIPTION
Hi, i have incredible fix)
There is mistyping in main example at README file, that generate such error: http://screencloud.net/v/gtpx
I just move curly bracket to another place, and everything become ok.
Think it would helpful for other people...
