### PR TITLE
Use options.url over host/port when set

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ RedisSessions = (function(superClass) {
     this.redisns = this.redisns + ":";
     if (((ref = o.client) != null ? (ref1 = ref.constructor) != null ? ref1.name : void 0 : void 0) === "RedisClient") {
       this.redis = o.client;
+    } else if (o.options && o.options.url) {
+      this.redis = RedisInst.createClient(o.options);
     } else {
       this.redis = RedisInst.createClient(o.port || 6379, o.host || "127.0.0.1", o.options || {});
     }


### PR DESCRIPTION
When passing in a redis URL in the format `redis://user:secret@localhost:6379/0?foo=bar&qux=baz` in `options`, the current code still attempts to connect to a host/port of `127.0.0.1`/`6379`, causing two connection attempts to redis. If the redis url is set, we can connect directly by just passing the options and omitting the host/port all together.

This allows for connecting to redis correctly with just this:

```javascript
redisClient = new RedisSessions({
    options: {
      url: 'redis://user:secret@localhost:6379/0?foo=bar&qux=baz'
    }
});
```

https://github.com/NodeRedis/node_redis#options-object-properties

This PR adds a check when connecting to redis to see if `options.url` is set before falling back to the host/port solution described above.